### PR TITLE
Fixed URL of continuous integration builds in firmware-update.mdx

### DIFF
--- a/docs/tutorial-basics/firmware-update.mdx
+++ b/docs/tutorial-basics/firmware-update.mdx
@@ -21,7 +21,7 @@ There's two types of firmware releases: the bleeding edge and olde trusty.
 
 This is your best bet at the moment. Pirate-Bot compiles the latest code and uploads it to the forum every time there's a push to the git repository. Don't wait for lazy devs to prepare a release package.
 
-- [Download a bleeding edge release in the forum](https://forum.buspirate.com/t/bus-pirate-5-continuous-integration-builds)
+- [Download a bleeding edge release in the forum](https://forum.buspirate.com/t/bus-pirate-5-auto-build-main-branch/20/27)
 
 ### Olde trusty
 


### PR DESCRIPTION
The original link is broken.